### PR TITLE
fix chart filter errors

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -85,7 +85,7 @@ const IndexPage = ({ data }) => {
         <Grid.Column>
           <Item.Group>
             {orderedCallouts.map((c, i) => (
-              <Callout d={c} index={i} />
+              <Callout d={c} index={i} key={i} />
             ))}
             <Item key='read-more' style={{ background: `#d3e3ff`, padding: `.8em` }}>
               <Item.Content verticalAlign='middle'>


### PR DESCRIPTION
The bug was in Airtable! A few blank rows were causing the filter methods to fail. I simply deleted empty rows. 

This code change fixes a small React console warning.