### PR TITLE
add parsely analytics tracking

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -80,6 +80,13 @@ module.exports = {
         trackingId: `UA-24107680-1`
       }
     },
+    {
+      resolve: `gatsby-plugin-parsely-analytics`,
+      options: {
+        apikey: `publicsource.org`,
+        enableInDevelopment: false // send page views when NODE_ENV !== prod
+      }
+    }
     // this (optional) plugin enables Progressive Web App + Offline functionality
     // To learn more, visit: https://gatsby.dev/offline
     // `gatsby-plugin-offline`,

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "gatsby-plugin-less": "^3.0.5",
     "gatsby-plugin-manifest": "^2.2.5",
     "gatsby-plugin-offline": "^2.2.6",
+    "gatsby-plugin-parsely-analytics": "^1.1.0",
     "gatsby-plugin-react-helmet": "^3.1.3",
     "gatsby-plugin-sharp": "^2.2.11",
     "gatsby-plugin-web-font-loader": "^1.0.4",

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -43,7 +43,6 @@ const Layout = ({ children }) => (
       }}>
         <span>© Copyright 2020, PublicSource</span>
     </footer>
-    <script id="parsely-cfg" src="//cdn.parsely.com/keys/publicsource.org/p.js"></script>
   </>
 )
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5869,6 +5869,11 @@ gatsby-plugin-page-creator@^2.3.7:
     lodash "^4.17.15"
     micromatch "^3.1.10"
 
+gatsby-plugin-parsely-analytics@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-parsely-analytics/-/gatsby-plugin-parsely-analytics-1.1.0.tgz#004202fc53f214e02679ebf3ffb04e4454b5cdd3"
+  integrity sha512-QHyp9C5A1eYV/BEdnrZdwpA5K8el4wltTJ1jhSK1b8kVkxE1TmFyCh4pMSm7TXkoLeGARbPSjB4r0rm4L94cgg==
+
 gatsby-plugin-react-helmet@^3.1.3:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/gatsby-plugin-react-helmet/-/gatsby-plugin-react-helmet-3.3.2.tgz#5619a1808d9607eb89c19d3f04854f497c6fb890"


### PR DESCRIPTION
Using this Gatsby plugin https://www.gatsbyjs.com/plugins/gatsby-plugin-parsely-analytics/ 

Injects script into the bottom of `<body>` on each page like this:
![Screenshot from 2022-03-07 22-57-03](https://user-images.githubusercontent.com/5132349/157124732-592cb8ab-0ef5-4535-97ac-6796d1330d0f.png)